### PR TITLE
Adding 'terminals' tag to Grammar string input.

### DIFF
--- a/lexer.py
+++ b/lexer.py
@@ -199,6 +199,8 @@ OUTAPPEND_REDIR: '>>' filespec;
 ERR_REDIR: '2>' filespec 
 | ERRAPPEND_REDIR;
 ERRAPPEND_REDIR: '2>>' filespec;
+
+terminals
 space: /[\t ]+/;
 arg: /([^">< ]+|"[^"]+")+/;
 keyword: /\w+/;


### PR DESCRIPTION
Without this tag parglare raise exception ParseError:
"Error at 22:7:"c;\nspace: */[\t ]+/;\n" => Expected:
Name or StrConst but found <NotComment(/[\t)> or <RegExTerm(/[\t ]+/)>"